### PR TITLE
Setup yapf diff on push to any branch

### DIFF
--- a/.github/workflows/yapf_check.yml
+++ b/.github/workflows/yapf_check.yml
@@ -1,0 +1,12 @@
+name: YAPF Formatting Check
+on: [push]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run YAPF python style checks
+        uses: AlexanderMelde/yapf-action@master
+        with:
+          args: --diff --recursive --style env/.style.yapf .

--- a/.github/workflows/yapf_check.yml
+++ b/.github/workflows/yapf_check.yml
@@ -9,4 +9,4 @@ jobs:
       - name: Run YAPF python style checks
         uses: AlexanderMelde/yapf-action@master
         with:
-          args: --diff --recursive --style env/.style.yapf .
+          args: --diff --recursive --style env/.style.yapf

--- a/lint_parser_hal.py
+++ b/lint_parser_hal.py
@@ -50,7 +50,6 @@ def parse_args(argv):
     options = parser.parse_args(argv)
     return options
 
-
 def find_bazel_runfiles(relpath, bazel_target):
     p = subprocess.Popen("bazel info", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.wait()

--- a/lint_parser_hal.py
+++ b/lint_parser_hal.py
@@ -50,6 +50,7 @@ def parse_args(argv):
     options = parser.parse_args(argv)
     return options
 
+
 def find_bazel_runfiles(relpath, bazel_target):
     p = subprocess.Popen("bazel info", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.wait()


### PR DESCRIPTION
I tested the yapf action a little. I introduced a yapf error into lint_parser_hal.py to make sure that this yapf action flagged it - https://github.com/Lightelligence/rules_verilog/runs/2063129121

I'm throwing the `--recursive` flag to yapf like the `--help` page suggests, but I didn't try to test the recursive discovery. I can test that out after we get a few more python files in the repo.