### PR TITLE
Refactored CDC arguments to better match common use cases

### DIFF
--- a/vendors/cadence/verilog_rtl_cdc_test.sh.template
+++ b/vendors/cadence/verilog_rtl_cdc_test.sh.template
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# This is a template for the bazel verilog_rtl_cdc_test rule
+# It is not intended to be run stand-alone
 set -e
 
 use_gui=0
@@ -21,7 +23,7 @@ then
     no_gui_flag=""
 fi
 
-runmod -t jg -- \
+{CDC_COMMAND} \
   -cdc \
   $no_gui_flag \
   -proj cdc_run \

--- a/vendors/cadence/verilog_rtl_cdc_test.sh.template
+++ b/vendors/cadence/verilog_rtl_cdc_test.sh.template
@@ -29,7 +29,7 @@ fi
   -proj cdc_run \
   -define RULES_VERILOG_GUI $use_gui \
   {PREAMBLE_CMDS} \
-  {CMD_FILE} \
+  {CMD_FILES} \
   {EPILOGUE_CMDS} \
   $@
 ! grep "^\[*ERROR" cdc_run/jg.log

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -664,7 +664,7 @@ verilog_rtl_cdc_test = rule(
         ),
         "bbox_array_size": attr.int(
             default = 0,
-            doc = "Black box any RTL array greater than the specified size. If this attribute is not set, the CDC tool will use the default size",
+            doc = "Black box any RTL array greater than the specified size. If the value of this attribute is 0, the CDC tool will use the default size",
         ),
         "cmd_files": attr.label_list(
             allow_files = True,

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -593,7 +593,7 @@ def _verilog_rtl_cdc_test_impl(ctx):
         "set elaborate_single_run_mode True",
         "analyze -sv09 +libext+.v+.sv {} +define+LINT+CDC{} {} {}".format(bbox_cmd, "".join(defines), flists, top_mod),
         "elaborate {} -top {} {}".format(bbox_cmd, ctx.attr.top, bbox_a_cmd),
-        "check_cdc -check -rule -set {{cdc_pair_logic wire}}"
+        "check_cdc -check -rule -set {{cdc_pair_logic wire}}",
     ]
 
     epilogue_cmds_content = [

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -564,7 +564,7 @@ def _verilog_rtl_cdc_test_impl(ctx):
         substitutions = {
             "{CDC_COMMAND}": ctx.attr._command_override[ToolEncapsulationInfo].command,
             "{PREAMBLE_CMDS}": ctx.outputs.cdc_preamble_cmds.short_path,
-            "{CMD_FILE}": ctx.outputs.cdc_epilogue_cmds.short_path,
+            "{CMD_FILE}": ctx.files.cmd_file[0].short_path,
             "{EPILOGUE_CMDS}": ctx.outputs.cdc_epilogue_cmds.short_path,
         },
     )
@@ -593,7 +593,7 @@ def _verilog_rtl_cdc_test_impl(ctx):
         "set elaborate_single_run_mode True",
         "analyze -sv09 +libext+.v+.sv {} +define+LINT+CDC{} {} {}".format(bbox_cmd, "".join(defines), flists, top_mod),
         "elaborate {} -top {} {}".format(bbox_cmd, ctx.attr.top, bbox_a_cmd),
-        "check_cdc -check -rule -set {{treat_boundaries_as_unclocked true}}",
+        "check_cdc -check -rule -set {{cdc_pair_logic wire}}"
     ]
 
     epilogue_cmds_content = [

--- a/verilog/private/rtl.bzl
+++ b/verilog/private/rtl.bzl
@@ -586,17 +586,17 @@ def _verilog_rtl_cdc_test_impl(ctx):
     if top_mod == "":
         fail("verilog_rtl_cdc_test could not determine top_module from last_module variable")
 
-    bbox_size_cmd = ""
-    if ctx.attr.bbox_size < 0:
-        fail("verilog_rtl_cdc_test was specified with a negative bbox_size")
-    elif ctx.attr.bbox_size > 0:
-        bbox_size_cmd = "-bbox_a {}".format(ctx.attr.bbox_size)
+    bbox_array_size_cmd = ""
+    if ctx.attr.bbox_array_size < 0:
+        fail("verilog_rtl_cdc_test was specified with a negative bbox_array_size")
+    elif ctx.attr.bbox_array_size > 0:
+        bbox_array_size_cmd = "-bbox_a {}".format(ctx.attr.bbox_array_size)
 
     premable_cmds_content = [
         "clear -all",
         "set elaborate_single_run_mode True",
         "analyze -sv09 +libext+.v+.sv {} +define+LINT+CDC{} {} {}".format(bbox_modules_cmd, "".join(defines), flists, top_mod),
-        "elaborate {} -top {} {}".format(bbox_modules_cmd, ctx.attr.top, bbox_size_cmd),
+        "elaborate {} -top {} {}".format(bbox_modules_cmd, ctx.attr.top, bbox_array_size_cmd),
     ]
 
     epilogue_cmds_content = [
@@ -662,7 +662,7 @@ verilog_rtl_cdc_test = rule(
             default = [],
             doc = "List of modules to black box",
         ),
-        "bbox_size": attr.int(
+        "bbox_array_size": attr.int(
             default = 0,
             doc = "Black box any RTL array greater than the specified size. If this attribute is not set, the CDC tool will use the default size",
         ),


### PR DESCRIPTION
- Renamed `bbox` argument to `bbox_modules`
- Added `bbox_array_size` argument
- Added support for multiple tcl command files by changing `cmd_file` argument to `cmd_files`
- Fixed bug where template was using a hard-coded bash command instead of the `CDC_COMMAND` template argument