### PR TITLE
Add timeout option to verilog_dv_test_cfg

### DIFF
--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -7,7 +7,7 @@ DVTestInfo = provider(fields = {
     "uvm_testname": "UVM Test Name; passed to simulator via plusarg +UVM_TESTNAME.",
     "tb": "The verilog_dv_tb (verilog compile) associated with this test. Must be a Label of type verilog_dv_tb.",
     "tags": "Additional tags to be able to filter in simmer.",
-    "timeout" : "Duration in seconds before the test will be killed due to timeout.",
+    "timeout": "Duration in seconds before the test will be killed due to timeout.",
 })
 
 DVTBInfo = provider(fields = {

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -7,7 +7,7 @@ DVTestInfo = provider(fields = {
     "uvm_testname": "UVM Test Name; passed to simulator via plusarg +UVM_TESTNAME.",
     "tb": "The verilog_dv_tb (verilog compile) associated with this test. Must be a Label of type verilog_dv_tb.",
     "tags": "Additional tags to be able to filter in simmer.",
-    "timeout": "Duration in seconds before the test will be killed due to timeout.",
+    "timeout": "Duration in minutes before the test will be killed due to timeout.",
 })
 
 DVTBInfo = provider(fields = {

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -137,7 +137,7 @@ verilog_dv_test_cfg = rule(
         ),
         "timeout": attr.int(
             default = -1,
-            doc = "Duration in seconds before the test will be killed due to timeout.\n" +
+            doc = "Duration in minutes before the test will be killed due to timeout.\n" +
                   "This option is inheritable.",
         ),
     },


### PR DESCRIPTION
This option is intended to be used by the simulation launching tool to be able to set timeouts on a per test basis.

The choice to set the value in minutes is because seconds is too granular for this option. Most tests will be on the order of minutes to hours magnitude. I would have preferred to keep this in hours, but bazel does not a have a float attribute: https://docs.bazel.build/versions/main/skylark/lib/attr.html