### PR TITLE
Add licqueue option to Xcelium svunit template

### DIFF
--- a/cmn_logging.py
+++ b/cmn_logging.py
@@ -160,7 +160,8 @@ def _simple_test():
     log.exit_if_warnings_or_errors("Will not exit due to lack of previous errors")
     log.info("Message 2 prints.")
     log.error("Message 3 is an error and it will print.")
-    log.exit_if_warnings_or_errors("Message 4: exiting due to errors. " "This is the last message to print.")
+    log.exit_if_warnings_or_errors("Message 4: exiting due to errors. "
+                                   "This is the last message to print.")
     log.info("Will not get to this point.")
     # Expected output
     # INFO:main:Message 1 prints.

--- a/vendors/cadence/verilog_rtl_unit_test_svunit.sh.template
+++ b/vendors/cadence/verilog_rtl_unit_test_svunit.sh.template
@@ -18,6 +18,7 @@
     -c "-libext\ .vams" \
     -c "-disable_sem2009" \
     -c "-enable_single_yvlib" \
+    -c "-licqueue" \
     -c "-timescale\ 100fs/100fs" \
     -c "-vtimescale\ 100fs/100fs" \
     -c "-define\ TIMESCALE_STEP_FS=100" \


### PR DESCRIPTION
 svunit tests may fail if a license is not immediately available. The other templates have the licqueue option thrown, make svunit tests more similar.