### PR TITLE
Converted verilog_dv_test_cfg to output everything in *_dynamic_args

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,8 +68,9 @@ stardoc_repositories()
 
 http_archive(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    sha256 = "b07772d38ab07e55eca4d50f4b53da2d998bb221575c60a4f81100242d4b4889",
+    strip_prefix = "protobuf-3.20.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.0.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,5 @@
 workspace(name = "rules_verilog")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_verilog//:deps.bzl", "verilog_dependencies")
 
@@ -56,10 +55,13 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-git_repository(
+http_archive(
     name = "io_bazel_stardoc",
-    remote = "https://github.com/bazelbuild/stardoc.git",
-    tag = "0.4.0",
+    sha256 = "aa814dae0ac400bbab2e8881f9915c6f47c49664bf087c409a15f90438d2c23e",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+    ],
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
@@ -70,7 +72,7 @@ http_archive(
     name = "com_google_protobuf",
     sha256 = "b07772d38ab07e55eca4d50f4b53da2d998bb221575c60a4f81100242d4b4889",
     strip_prefix = "protobuf-3.20.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.0.tar.gz"],
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.20.0.tar.gz",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -79,6 +81,7 @@ protobuf_deps()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-master",
-    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+    sha256 = "b8fc5ee8f48a0f7ff0a72f8457aaefb5807777162caf6967c5648f73ae320cf3",
+    strip_prefix = "buildtools-master-5.5.1",
+    url = "https://github.com/bazelbuild/bazel/archive/refs/tags/5.1.1.tar.gz",
 )

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -56,17 +56,6 @@ def _verilog_dv_test_cfg_impl(ctx):
     provider_args["sim_opts"] = sim_opts
     provider_args["tags"] = ctx.attr.tags
 
-    sim_opts_str = "\n".join(["{}{}".format(key, value) for key, value in sim_opts.items()])
-
-    out = ctx.outputs.sim_args
-    ctx.actions.write(
-        output = out,
-        content = """+UVM_TESTNAME={uvm_testname}\n{sim_opts}""".format(
-            uvm_testname = uvm_testname,
-            sim_opts = sim_opts_str,
-        ),
-    )
-
     for socket_name, socket_command in ctx.attr.sockets.items():
         if "{socket_file}" not in socket_command:
             fail("socket {} did not have {{socket_file}} in socket_command".format(socket_name))
@@ -74,7 +63,10 @@ def _verilog_dv_test_cfg_impl(ctx):
     dynamic_args = {
         "sockets": ctx.attr.sockets,
         "timeout": timeout,
-    }
+        "sim_opts": sim_opts,
+        "uvm_testname": uvm_testname,
+        "tags": ctx.attr.tags,
+}
     out = ctx.outputs.dynamic_args
     ctx.actions.write(
         output = out,
@@ -142,7 +134,6 @@ verilog_dv_test_cfg = rule(
         ),
     },
     outputs = {
-        "sim_args": "%{name}_sim_args.f",
         "dynamic_args": "%{name}_dynamic_args.py",
     },
 )

--- a/verilog/private/dv.bzl
+++ b/verilog/private/dv.bzl
@@ -66,7 +66,7 @@ def _verilog_dv_test_cfg_impl(ctx):
         "sim_opts": sim_opts,
         "uvm_testname": uvm_testname,
         "tags": ctx.attr.tags,
-}
+    }
     out = ctx.outputs.dynamic_args
     ctx.actions.write(
         output = out,


### PR DESCRIPTION
Converted verilog_dv_test_cfg to output everything in *_dynamic_args.py instead of splitting between *_dynamic_args.py and _sim_args.f