### PR TITLE
Attempt to force GitHub to recognize .bzl and BUILD files as Starlark

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force GitHugb to recognize BUILD and *.bzl files with the Starlark language
+*.bzl linguist-language=Starlark
+BUILD linguist-language=Starlark


### PR DESCRIPTION
Followed the instructions in https://github.com/github/linguist/blob/master/docs/troubleshooting.md and https://github.com/github/linguist/blob/master/docs/overrides.md to associate .bzl and BUILD files with Starlark instead of Python.