### PR TITLE
fix the cov_opts issue that None type cannot be anded with the string opt…

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -1169,7 +1169,7 @@ class VCompJob(Job):
         if options.gui:
             enable_debug_access = 2
 
-        cov_opts = None
+        cov_opts = ''
         if options.coverage:
             self.cov_work_dir = os.path.join(self.rcfg.regression_dir, self.name + "__COV_WORK")
             os.system("mkdir -p {}".format(self.cov_work_dir))


### PR DESCRIPTION
…ions

` File "/nfs/workspace05/yyou/Aurora/bazel-bin/external/rules_verilog/bin/simmer.runfiles/rules_verilog/bin/simmer.py", line 1189, in pre_run
    cov_opts += ' -coverage {} '.format(options.coverage)
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
`