### PR TITLE
update the coverage options for the re-sim with the same seed

### DIFF
--- a/bin/simmer.py
+++ b/bin/simmer.py
@@ -889,6 +889,7 @@ class TestJob(Job):
             sockets.append((socket_name, socket_command, socket_file))
 
         if options.coverage:
+            sim_opts += ' -covoverwrite '
             sim_opts += ' -covworkdir {} '.format(self.vcomper.cov_work_dir)
             sim_opts += ' -covbaserun {} '.format(self.name)
             if 'A' in options.coverage or 'U' in options.coverage:


### PR DESCRIPTION
the option "-covoverwrite" is required if reruning the sim with the same seed, the new cov database will overwrite the previous database with the sim_opts